### PR TITLE
Add more of item, instead of creating a new entry with the same name

### DIFF
--- a/scribble.py
+++ b/scribble.py
@@ -168,7 +168,7 @@ def createLayoutMenu():
     return [[sg.Menu([['Add/Remove', ['Inventory', 'Enemies', 'Locations']], ['Search', ['Search']], ['Dice', ['Roller']], ['Settings', ['Edit Config']], ['Credits'], ['Quit']])]]
 
 def createLayoutInv():
-    return [[sg.Text('Add Item', font='_ 14')],
+    return [[sg.Text('Add/Remove Item', font='_ 14')],
             [sg.Text('Name:'), sg.Input(k = '-Item Name-', do_not_clear=False)],
             [sg.Text('Desc:'), sg.Input(k = '-Item Desc-', do_not_clear=False)],
             [sg.Text('Count:'), sg.Input(k = '-Item Count-', do_not_clear=False)],
@@ -196,6 +196,9 @@ def createLayoutSearch():
 def createLayoutButtons():
     return [[sg.Button('Enter')]]
 
+def createLayoutInvButtons():
+    return [[sg.Button('Enter'), sg.Button('Remove (only name & count needed, -1 count = all)')]]
+
 # return the created mainMenu window
 def makeMainMenuWindow():
     sg.theme(THEME) # set color palette / theme of application
@@ -206,7 +209,7 @@ def makeMainMenuWindow():
 def makeInventoryWindow():
     layout_final = [[createLayoutMenu()],
                     [createLayoutInv()],
-                    [createLayoutButtons()]]
+                    [createLayoutInvButtons()]]
     return sg.Window('Scribble', layout_final, size=(800,400))
 
 def makeEnemyWindow():

--- a/scribble.py
+++ b/scribble.py
@@ -197,7 +197,7 @@ def createLayoutButtons():
     return [[sg.Button('Enter')]]
 
 def createLayoutInvButtons():
-    return [[sg.Button('Enter'), sg.Button('Remove (only name & count needed, -1 count = all)')]]
+    return [[sg.Button('Enter'), sg.Button('Remove (only name & count needed, 0 count = all)')]]
 
 # return the created mainMenu window
 def makeMainMenuWindow():
@@ -229,7 +229,7 @@ def makeSearchWindow():
                     [createLayoutButtons()]]
     return sg.Window('Scribble', layout_final, size=(800,400))
 
-def invMenuLogic(values):
+def invMenuAddLogic(values):
     item = Item(values) # create item object
 
     # if inventory fields have data, add them to json
@@ -240,6 +240,45 @@ def invMenuLogic(values):
         print("Successfully printed to json")
     else:
         print("You are missing fields in item")
+
+def searchJsonViaName(values):
+    return 0
+
+def invMenuRemoveLogic(values):
+    inputValue = None # convert input to lowercase
+    count = None # how many of the item we want to remove
+    item = Item(values) # create item object
+    data = loadJsonFile(INVENTORY_JSON) # store entire inv .json in memory
+    matchingItems = [] # list storing all entires that match our input
+
+    # make sure inputs are not NULL or empty b4 setting them equal to variables
+    if values['-Item Count-'] == '' or values['-Item Count-'] == ' ' or values['-Item Count-'] == None:
+        print('Error: non-valid count input')
+    else:
+        count = int(values['-Item Count-'])
+
+    if values['-Item Name-'] == '' or values['-Item Name-'] == ' ' or values['-Item Name-'] == None:
+        print('Error: non-valid name input')
+    else:
+        inputValue = values['-Item Name-']
+
+    # search database for item
+    for x in data:
+        if x['name'].lower() == inputValue:
+            matchingItems.append(x)
+
+    # remove items stored in 'matchingItems' list by count
+    if matchingItems and count > 0:
+        for x in matchingItems:
+            x['count'] = int(x['count']) - count
+            if int(x['count']) < 0:
+                x['count'] = 0
+        print('Successfully removed item of specific count')
+    elif matchingItems and count <= 0: # remove all items
+        for x in matchingItems:
+            x['count'] = 0
+        print('Successfully removed all of that item')
+
 
 def enemiesMenuLogic(values):
     enemy = Enemy(values['-Enemy Name-'], values['-Enemy Desc-'])
@@ -322,13 +361,15 @@ def runApplication(window):
 
         # logic for each window: Inventory, Enemies
         if event == 'Enter' and CURRENT_WINDOW == 'Inventory':
-            invMenuLogic(values)
+            invMenuAddLogic(values)
         elif event == 'Enter' and CURRENT_WINDOW == 'Enemies':
             enemiesMenuLogic(values)
         elif event == 'Roll' and CURRENT_WINDOW == 'Roller': #Large piece for rolling, took a lot more lines than I thought
             diceMenuLogic(window, values)
         elif event == 'Enter' and CURRENT_WINDOW == 'Search':
             searchMenuInventoryLogic(values)
+        elif event == 'Remove (only name & count needed, 0 count = all)':
+            invMenuRemoveLogic(values)
 
 
 window = makeMainMenuWindow() # create the first initial window

--- a/scribble.py
+++ b/scribble.py
@@ -169,9 +169,9 @@ def createLayoutMenu():
 
 def createLayoutInv():
     return [[sg.Text('Add/Remove Item', font='_ 14')],
-            [sg.Text('Name:'), sg.Input(k = '-Item Name-', do_not_clear=False)],
-            [sg.Text('Desc:'), sg.Input(k = '-Item Desc-', do_not_clear=False)],
-            [sg.Text('Count:'), sg.Input(k = '-Item Count-', do_not_clear=False)],
+            [sg.Text('Name:'), sg.Input(k = '-Item Name-', do_not_clear=False, s=(15,1))],
+            [sg.Text('Desc:'), sg.Input(k = '-Item Desc-', do_not_clear=False, s=(25,1))],
+            [sg.Text('Count:'), sg.Input(k = '-Item Count-', do_not_clear=False, s=(5,1))],
             [sg.Radio('Active', 1, key='-Item Active-'), sg.Radio('Passive', 1, key='-Item Passive-')],
             [sg.Radio('Key', 2, key='-Item Key-'), sg.Radio('Not Key', 2, key='-Item NotKey-')]]
 
@@ -197,7 +197,9 @@ def createLayoutButtons():
     return [[sg.Button('Enter')]]
 
 def createLayoutInvButtons():
-    return [[sg.Button('Enter'), sg.Button('Remove (only name & count needed, -1 count = database removal)')]]
+    return [[sg.Button('Enter'), sg.Button('Remove')],
+            [sg.Text('- Enter: Type JUST name and count to add more of this item to inv.')],
+            [sg.Text('- Remove: Type JUST name and count, # for that amount, 0 to set 0, or -1 to completely remove')]]
 
 # return the created mainMenu window
 def makeMainMenuWindow():
@@ -261,8 +263,7 @@ def invMenuRemoveLogic(values):
                 else:
                     data.remove(item)
                     removed = True
-            else:
-                # Decrease the count of the item by the specified amount
+            elif count > 0: # Decrease the count of the item by the specified amount
                 newCount = max(0, itemCount - count)
                 item['count'] = newCount
                 if newCount == 0:
@@ -270,6 +271,10 @@ def invMenuRemoveLogic(values):
                     removed = True
                 else:
                     print(f'Successfully removed {count} of that item.')
+            else: # set equal to 0
+                newCount = 0
+                item['count'] = newCount
+                removed = True
 
     if removed:
         print('Successfully removed item(s).')
@@ -367,7 +372,7 @@ def runApplication(window):
             diceMenuLogic(window, values)
         elif event == 'Enter' and CURRENT_WINDOW == 'Search':
             searchMenuInventoryLogic(values)
-        elif event == 'Remove (only name & count needed, -1 count = database removal)':
+        elif event == 'Remove':
             invMenuRemoveLogic(values)
 
 


### PR DESCRIPTION
# Add to pre-existing items instead of replacing them or creating new data-entry with the same name
When adding items, you could add a data-entry with the same name even if it was pre-existing. 

This is no longer the case.

During the add logic, if the item is found to already exist, it just increases the count that was inputted when adding.

Example:

*item 'sword' exist in database, count 1*
*user adds 'sword', with count = 15*
*instead of new entry being created, the sword count is increased by +15*
*searching sword will prove this: only one entry for 'sword' will exist with count = 16*

# Removing Items
User can now add items to the database, AND remove them.

Go to search and type that item name to check if it's in the database

User can go back to inventory add/remove and do three of the following:

    type name and number to remove that specific amount
    type name and 0 to set count to 0
    type name and -1 to complete erase from the .json file

use the search feature to debug and make sure all three of these features work, they worked for me.
